### PR TITLE
artillery_type_table 추가 / number만 입력하도록 수정

### DIFF
--- a/arma3_artillery_calc.py
+++ b/arma3_artillery_calc.py
@@ -2,38 +2,106 @@ from fractions import Fraction
 import numpy as np
 import sympy as s
 
-velocity_table = [153.9,243,388.8,648,810]
-charge_level = -1
+artillery_type_table = ['Exit Program', 'M109A6 & Sholef', 'Panzerhaubitze2000', 'M252 (81mm)', 'M119A2 (105mm)']
+min_distance_table   = [0, 300, 400, 50, 300] # vel_charge_calc 로직과 함께 추후 수정 필요
 
-def artillery_calc_mod1():
+# 포 종류(art_type)와 거리(rx)를 입력 받아, 포구 속도(V)와 장약(charge_level) 결정
+# 수정 필요
+def vel_charge_calc(rx, art_type): 
+    if art_type == 1: # M109A6(Paladin) & Sholef
+        velocity_table = [153.9, 243, 388.8, 648, 810]
+        if rx < 300 or rx > 29900:
+            return -1, -1
+        elif rx >= 300 and rx < 2500:
+            charge_level = 0
+        elif rx >= 2500 and rx < 6100:
+            charge_level = 1
+        elif rx >= 6100 and rx < 15500:
+            charge_level = 2
+        elif rx >= 15500 and rx <= 29900:
+            charge_level = 3
+        v = velocity_table[charge_level]
+    elif art_type == 2: # Panzerhaubitze2000(PzH2000)
+        velocity_table = [222.8, 259.2, 291.6, 344.3, 405.0, 477.9, 550.8]
+        if rx < 400 or rx > 29900:
+            return -1, -1
+        elif rx >= 400 and rx < 5100:
+            charge_level = 0
+        elif rx >= 5100 and rx < 6900:
+            charge_level = 1
+        elif rx >= 6900 and rx < 8700:
+            charge_level = 2
+        elif rx >= 8700 and rx < 12100:
+            charge_level = 3
+        elif rx >= 12100 and rx < 16800:
+            charge_level = 4
+        elif rx >= 16800 and rx < 23300:
+            charge_level = 5
+        elif rx >= 23300 and rx < 29900:
+            charge_level = 6
+        v = velocity_table[charge_level]
+    elif art_type == 3: # M252 (81mm)
+        velocity_table = [70, 140, 200]
+        if rx <50 or rx > 4050:
+            return -1, -1
+        elif rx >= 50 and rx < 450:
+            charge_level = 0
+        elif rx >= 450 and rx < 1950:
+            charge_level = 1
+        elif rx >= 1950 and rx < 4050:
+            charge_level = 2
+        v = velocity_table[charge_level]
+    elif art_type == 4: # M119A2 (105mm)
+        velocity_table = [153.9, 243, 388.8]
+        if rx < 300 or rx > 15400:
+            return -1, -1
+        elif rx >= 300 and rx < 2500:
+            charge_level = 0
+        elif rx >= 2500 and rx < 6100:
+            charge_level = 1
+        elif rx >= 6100 and rx < 154000:
+            charge_level = 2
+        v = velocity_table[charge_level]
+    else:
+        return -2, -2
+    
+    return v, charge_level
+
+# 사용자가 number 타입만 입력하도록 안내
+# isCoordinate = True 일 경우만 5자리 입력하도록 추가 안내
+def get_number_input(prompt, isCoordinate = False):
+    while True:
+        try:
+            if isCoordinate:
+                axis_input = input(prompt)
+                if len(axis_input) == 5:
+                    return int(axis_input)
+                else:
+                    print("[Error] invalid value")
+                    print("[Error] input 5 number (ex. 12300)")
+            else :
+                return int(input(prompt))
+        except ValueError:
+            print("[Error] invalid value")
+            print("[Error] input number value")
+
+def artillery_calc_mod1(art_type):
 
     print('\n[+] please input 10 step coordinates (ex. 123 456 => 12300 45600)')
-    x1 = int(input('your x-axis coordinate > '))
-    y1 = int(input('your y-axis coordinate > '))
-    z1 = int(input('your altitude > '))
-    x2 = int(input('target x-axis coordinate > '))
-    y2 = int(input('target y-axis coordinate > '))
-    z2 = int(input('target altitude > '))
+    x1 = get_number_input('your x-axis coordinate > ', True)
+    y1 = get_number_input('your y-axis coordinate > ', True)
+    z1 = get_number_input('your altitude > ')
+    x2 = get_number_input('target x-axis coordinate > ', True)
+    y2 = get_number_input('target y-axis coordinate > ', True)
+    z2 = get_number_input('target altitude > ')
 
     angle = s.atan2((x1 - x2), (y1 - y2)) * float(Fraction(180, Fraction(np.pi)) * Fraction(6400, 360))
     rx = round(np.sqrt(((x1 - x2)**2) + ((y1 - y2)**2)))
-
-    if rx < 300 or rx > 29900:
-        print('invalid distance')
-        print('distance : ' + str(rx))
+    v, charge_level = vel_charge_calc(rx, art_type)
+    if v == -1:
+        print('[Error] invalid distance')
+        print('[Error] distance : ' + str(rx))
         return
-    elif rx >= 300 and rx < 2500:
-        charge_level = 0
-        v = velocity_table[charge_level]
-    elif rx >= 2500 and rx < 6100:
-        charge_level = 1
-        v = velocity_table[charge_level]
-    elif rx >= 6100 and rx < 15500:
-        charge_level = 2
-        v = velocity_table[charge_level]
-    elif rx >= 15500 and rx <= 29900:
-        charge_level = 3
-        v = velocity_table[charge_level]
 
     v2 = v*v
     v4 = v2*v2
@@ -58,37 +126,25 @@ def artillery_calc_mod1():
     sk *= (6400/360)
     sa *= (6400/360)
 
-    print()
+    print('============================================')
     print('[+] Shooting Angle : ' + str(round(angle)))
     print('[+] Low angle elevation : ' + str(round(sk)))
     print('[+] Low ELEV ETA : ' + str(eta_l))
     print('[+] High angle elevation : ' + str(round(sa)))
     print('[+] High ELEV ETA : ' + str(eta_h))
     print('[+] Charge level : ' + str(charge_level))
-    print()
+    print('============================================')
 
-def artillery_calc_mod2():
+def artillery_calc_mod2(art_type):
 
-    rx = int(input('distance between you and the target (minimum = 300) > '))
-    z1 = int(input('your altitude > '))
-    z2 = int(input('target altitude > '))
-
-    if rx < 300 or rx > 29900:
-        print('invalid distance')
-        print('distance : ' + str(rx))
+    rx = get_number_input('distance between you and the target (minimum = ' + str(min_distance_table[art_type]) + ') > ')
+    z1 = get_number_input('your altitude > ')
+    z2 = get_number_input('target altitude > ')
+    v, charge_level = vel_charge_calc(rx, art_type)
+    if v == -1:
+        print('[Error] invalid distance')
+        print('[Error] distance : ' + str(rx))
         return
-    elif rx >= 300 and rx < 2500:
-        charge_level = 0
-        v = velocity_table[charge_level]
-    elif rx >= 2500 and rx < 6100:
-        charge_level = 1
-        v = velocity_table[charge_level]
-    elif rx >= 6100 and rx < 15500:
-        charge_level = 2
-        v = velocity_table[charge_level]
-    elif rx >= 15500 and rx <= 29900:
-        charge_level = 3
-        v = velocity_table[charge_level]
 
     v2 = v*v
     v4 = v2*v2
@@ -107,27 +163,38 @@ def artillery_calc_mod2():
     sk *= (6400/360)
     sa *= (6400/360)
 
-    print()
+    print('============================================')
     print('[+] Low angle elevation : ' + str(round(sk)))
     print('[+] Low ELEV ETA : ' + str(eta_l))
     print('[+] High angle elevation : ' + str(round(sa)))
     print('[+] High ELEV ETA : ' + str(eta_h))
     print('[+] Charge level : ' + str(charge_level))
-    print()
+    print('============================================')
 
+# 포 종류(art_type) 선택 시 0번 입력하여 프로그램 종료하지 않는 이상 계속 반복
 if __name__ == '__main__':
+    while True:
+        print('\nArma3 Artillery Calculator')
+        print('Select type of artillery')
+        for idx, val in enumerate(artillery_type_table):
+            print(f'{idx}. {val}')
+        art_type = get_number_input('> ')
+        if art_type == 0:
+            break
+        elif art_type > len(artillery_type_table) - 1:
+            print('[Error] invalid type')
+            print('[Error] please input 1 ~ ' + str(len(artillery_type_table) - 1))
+            continue
+        print('Select calculate mode')
+        print('1. coordinate-based calculation mode')
+        print('2. distance-based calculation mode')
 
-    print('\narma3 M4 Scorcher 155mm artillery calculator\n')
-    print('select calculate mode')
-    print('1. coordinate-based calculation mode')
-    print('2. distance-based calculation mode')
+        mode = get_number_input('> ')
 
-    mode = int(input('> '))
-
-    if mode == 1:
-        artillery_calc_mod1()
-    elif mode == 2:
-        artillery_calc_mod2()
-    else:
-        print('[+] invalid input')
-        print('[+] please input 1 or 2')
+        if mode == 1:
+            artillery_calc_mod1(art_type)
+        elif mode == 2:
+            artillery_calc_mod2(art_type)
+        else:
+            print('[Error] invalid input')
+            print('[Error] please input 1 or 2')


### PR DESCRIPTION
1. artillery_type_table 추가
    - MRLS 제외한 모든 포 타입 테이블 추가
    - 각 포 타입별 장약과 포구속도 산출 로직 함수 분리

2. input 입력 값을 number 타입으로 안내하는 함수 추가
    - 입력 값 Error로 인한 프로그램 강제 종료 방지
    - 좌표 입력 시 5자리씩 입력하도록 안내

3. Main 함수 반복하도록 로직 수정
    - 포 타입 선택창에서 사용자가 직접 프로그램 종료하지 않으면, 계속해서 로직 진행하도록 반복문 추가